### PR TITLE
feat: add blog cover image support and redesign post card UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,11 @@ Resources: `auth`, `posts`, `products` (public + `/admin/products`), `cart`, `or
 
 - 超商取貨（`store_info`）：payload 支援，前台無選擇 UI
 - 購物車在下單後未清空
+
+## Coding Style
+
+完整規則見 `docs/coding-style.md`。重點摘要：
+
+- **Formatter**：Prettier（no semi、single quote、trailing comma all、arrowParens avoid）；Tailwind 類別由 `prettier-plugin-tailwindcss` 自動排序
+- **TypeScript**：禁用 `any`；catch 用 `unknown` + `instanceof Error`；nullable 欄位用 `T | null`
+- **Vue 屬性順序**：`ref/key` → `v-model` → 靜態屬性 → `:動態綁定` → `@事件`

--- a/api/posts/types/index.ts
+++ b/api/posts/types/index.ts
@@ -7,7 +7,7 @@ export interface Post {
   author: string
   is_enabled: number
   is_pinned: number
-  og_image: string
+  og_image: string | null
   status: string
   created_at?: string
   updated_at?: string
@@ -18,6 +18,7 @@ export interface CreatePostPayload {
   slug: string
   metaDescription: string
   content: string
+  og_image?: string | null
 }
 
 export interface CreatePostResponse {

--- a/components/blog/Post.vue
+++ b/components/blog/Post.vue
@@ -1,27 +1,67 @@
 <template>
-  <div class="mt-10 border-b border-gray-200 px-4 text-left lg:p-4">
-    <NuxtLink :to="`/blog/${item.id}/${item.slug}`">
-      <h3 class="">{{ item.title }}</h3>
-      <h5 class="mt-4 font-normal text-gray-600">
-        {{ item.meta_description }}
-      </h5>
-      <p class="mt-4 text-gray-500">
-        最後更新：
-        {{ formateUpdateDate(item.updated_at) }}
-      </p>
+  <article class="group border-b border-gray-100 py-8 last:border-b-0">
+    <NuxtLink
+      :to="`/blog/${item.id}/${item.slug}`"
+      class="flex items-start gap-6 sm:gap-8"
+    >
+      <div class="flex min-w-0 flex-1 flex-col">
+        <h2
+          class="line-clamp-2 text-lg leading-snug font-bold text-gray-900 transition-colors group-hover:text-gray-500 sm:text-xl"
+        >
+          {{ item.title }}
+        </h2>
+
+        <p
+          v-if="item.meta_description"
+          class="mt-2 line-clamp-2 text-sm leading-relaxed text-gray-500 sm:text-base"
+        >
+          {{ item.meta_description }}
+        </p>
+
+        <div
+          class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-400"
+        >
+          <span
+            v-if="item.is_pinned"
+            class="rounded-full bg-gray-100 px-2.5 py-0.5 font-medium text-gray-600"
+          >
+            置頂
+          </span>
+          <span>{{ formatDate(item.updated_at) }}</span>
+          <span aria-hidden="true">·</span>
+          <span>{{ readingTime }} 分鐘閱讀</span>
+        </div>
+      </div>
+
+      <div v-if="item.og_image" class="shrink-0">
+        <img
+          :src="item.og_image"
+          :alt="item.title"
+          class="h-24 w-36 rounded object-cover sm:h-28 sm:w-44"
+        />
+      </div>
     </NuxtLink>
-  </div>
+  </article>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Post } from '~/api/posts/types'
 
-defineProps<{
-  item: Post
-}>()
+const props = defineProps<{ item: Post }>()
 
-const formateUpdateDate = (updated?: string) => {
-  if (!updated) return ''
-  return new Date(updated).toISOString().split('T')[0] || ''
+const readingTime = computed(() => {
+  const text = props.item.content?.replace(/<[^>]*>/g, '') ?? ''
+  const words = text.trim().split(/\s+/).filter(Boolean).length
+  return Math.max(1, Math.ceil(words / 200))
+})
+
+const formatDate = (date?: string) => {
+  if (!date) return ''
+  return new Date(date).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
 }
 </script>

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -1,0 +1,88 @@
+# Coding Style
+
+## Formatter — Prettier
+
+設定檔：`.prettierrc.json`
+
+| 規則 | 值 | 說明 |
+|---|---|---|
+| `printWidth` | 80 | 每行最多 80 字元 |
+| `tabWidth` | 2 | 縮排 2 空格 |
+| `useTabs` | false | 空格縮排，不用 tab |
+| `semi` | false | 不加分號 |
+| `singleQuote` | true | 字串用單引號 |
+| `trailingComma` | all | 多行結尾加逗號 |
+| `arrowParens` | avoid | 單參數箭頭函式不加括號，例如 `x => x` |
+| `htmlWhitespaceSensitivity` | ignore | HTML 空白不敏感 |
+
+Tailwind 類別由 `prettier-plugin-tailwindcss` 自動排序，不需手動整理順序。
+
+---
+
+## Linter — ESLint
+
+設定檔：`eslint.config.mjs`，使用 `@nuxt/eslint` + `eslint-config-prettier`。
+
+---
+
+## TypeScript
+
+- **禁止使用 `any`**，catch 變數用 `unknown` 搭配 `instanceof` 型別縮窄：
+
+```ts
+// ✗
+} catch (err: any) {
+  alert(err.message)
+}
+
+// ✓
+} catch (err) {
+  alert(err instanceof Error ? err.message : '未知錯誤')
+}
+```
+
+- nullable 欄位型別用 `T | null`，非 `T | undefined`，例如 `og_image: string | null`
+
+---
+
+## Vue 模板屬性順序
+
+依照 `vue/attributes-order` 規則，屬性由上到下依序：
+
+1. `ref`、`key`（UNIQUE）
+2. `v-model`（TWO_WAY_BINDING）
+3. 靜態 HTML 屬性：`type`、`class`、`placeholder`（ATTR_STATIC）
+4. 動態綁定：`:disabled`、`:class`、`:src`（ATTR_DYNAMIC）
+5. 事件：`@click`、`@change`（EVENTS）
+
+```html
+<!-- ✗ -->
+<button @click="submit" :disabled="loading" :class="{ active }">
+
+<!-- ✓ -->
+<button :disabled="loading" :class="{ active }" @click="submit">
+```
+
+```html
+<!-- input 範例 -->
+<input
+  ref="fileInput"
+  type="file"
+  class="hidden"
+  @change="handleUpload"
+/>
+```
+
+---
+
+## Vue SFC 結構
+
+- 使用 `<script lang="ts" setup>`（Composition API + setup syntax）
+- 順序：`<template>` → `<script>` → `<style>`（如有）
+
+---
+
+## 錯誤處理
+
+- API 錯誤統一在 catch 用 `instanceof Error` 縮窄型別
+- 不用 `err.response?.data?.message` 的鏈式存取，避免繞過型別檢查

--- a/pages/admin/posts/create.vue
+++ b/pages/admin/posts/create.vue
@@ -29,6 +29,36 @@
       rows="3"
     ></textarea>
 
+    <!-- 封面圖 -->
+    <div class="mb-4">
+      <p class="mb-1 text-sm font-medium text-gray-700">封面圖</p>
+      <div
+        v-if="coverImageUrl"
+        class="relative w-full overflow-hidden rounded border border-gray-200"
+      >
+        <img
+          :src="coverImageUrl"
+          alt="封面圖預覽"
+          class="h-48 w-full object-cover"
+        />
+        <button type="button" @click="removeCoverImage">移除</button>
+      </div>
+      <label
+        v-else
+        class="flex h-32 w-full cursor-pointer flex-col items-center justify-center rounded border-2 border-dashed border-gray-300 text-sm text-gray-400 hover:border-gray-400"
+      >
+        <span v-if="coverImageUploading">上傳中...</span>
+        <span v-else>點擊上傳封面圖</span>
+        <input
+          ref="coverImageInput"
+          type="file"
+          accept="image/*"
+          class="hidden"
+          @change="handleCoverImageUpload"
+        />
+      </label>
+    </div>
+
     <!-- 做成元件 -->
     <UModal v-model:open="showModal" title="設定圖片資訊">
       <template #body>
@@ -61,25 +91,25 @@
       <div class="control-group">
         <div class="button-group mb-4">
           <button
-            @click="editor.chain().focus().toggleBold().run()"
             :disabled="!editor.can().chain().focus().toggleBold().run()"
             :class="{ 'is-active': editor.isActive('bold') }"
+            @click="editor.chain().focus().toggleBold().run()"
           >
             Bold
           </button>
 
           <button
-            @click="editor.chain().focus().toggleItalic().run()"
             :disabled="!editor.can().chain().focus().toggleItalic().run()"
             :class="{ 'is-active': editor.isActive('italic') }"
+            @click="editor.chain().focus().toggleItalic().run()"
           >
             Italic
           </button>
 
           <button
-            @click="editor.chain().focus().toggleStrike().run()"
             :disabled="!editor.can().chain().focus().toggleStrike().run()"
             :class="{ 'is-active': editor.isActive('strike') }"
+            @click="editor.chain().focus().toggleStrike().run()"
           >
             Strike
           </button>
@@ -87,115 +117,115 @@
           <!-- upload image  -->
           <button @click="triggerFileInput">Upload Image</button>
           <input
-            type="file"
-            @change="handleUploadImage"
-            class="hidden"
             ref="fileInput"
+            type="file"
+            class="hidden"
+            @change="handleUploadImage"
           />
           <button @click="addImage">Set Image URL</button>
 
           <button
-            @click="editor.chain().focus().toggleCode().run()"
             :disabled="!editor.can().chain().focus().toggleCode().run()"
             :class="{ 'is-active': editor.isActive('code') }"
+            @click="editor.chain().focus().toggleCode().run()"
           >
             <Icon name="i-ic:baseline-code" />
           </button>
 
           <button
-            @click="editor.chain().focus().toggleCodeBlock().run()"
             :class="{ 'is-active': editor.isActive('codeBlock') }"
+            @click="editor.chain().focus().toggleCodeBlock().run()"
           >
             Code block
           </button>
 
           <button
-            @click="editor.chain().focus().setParagraph().run()"
             :class="{ 'is-active': editor.isActive('paragraph') }"
+            @click="editor.chain().focus().setParagraph().run()"
           >
             Paragraph
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 1 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
           >
             H1
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 2 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
           >
             H2
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 3 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
           >
             H3
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 4 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 4 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 4 }).run()"
           >
             H4
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 5 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 5 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 5 }).run()"
           >
             H5
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 6 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 6 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 6 }).run()"
           >
             H6
           </button>
 
           <button
-            @click="editor.chain().focus().toggleBulletList().run()"
             :class="{ 'is-active': editor.isActive('bulletList') }"
+            @click="editor.chain().focus().toggleBulletList().run()"
           >
             Bullet list
           </button>
 
           <button
-            @click="editor.chain().focus().toggleOrderedList().run()"
             :class="{ 'is-active': editor.isActive('orderedList') }"
+            @click="editor.chain().focus().toggleOrderedList().run()"
           >
             Ordered list
           </button>
 
           <button
-            @click="setLink"
             :class="{ 'is-active': editor.isActive('link') }"
+            @click="setLink"
           >
             Set link
           </button>
 
           <button
-            @click="editor.chain().focus().unsetLink().run()"
             :disabled="!editor.isActive('link')"
+            @click="editor.chain().focus().unsetLink().run()"
           >
             Unset link
           </button>
 
           <button
-            @click="editor.chain().focus().undo().run()"
             :disabled="!editor.can().chain().focus().undo().run()"
+            @click="editor.chain().focus().undo().run()"
           >
             <Icon name="i-flowbite:undo-outline" />
           </button>
 
           <button
-            @click="editor.chain().focus().redo().run()"
             :disabled="!editor.can().chain().focus().redo().run()"
+            @click="editor.chain().focus().redo().run()"
           >
             <Icon name="i-flowbite:undo-solid" />
           </button>
@@ -235,8 +265,6 @@
       </div>
       <editor-content :editor="editor" class="border border-gray-300" />
     </div>
-
-    <!-- <div v-html="articleContent" class="tiptap"></div> -->
   </div>
 </template>
 
@@ -267,6 +295,29 @@ lowlight.register('js', js)
 const title = ref('')
 const slug = ref('')
 const metaDescription = ref('')
+const coverImageUrl = ref<string | null>(null)
+const coverImageUploading = ref(false)
+const coverImageInput = ref<HTMLInputElement | null>(null)
+
+async function handleCoverImageUpload(event: Event) {
+  const target = event.target as HTMLInputElement | null
+  const file = target?.files?.[0]
+  if (!file) return
+  coverImageUploading.value = true
+  try {
+    const { data } = await uploadImage(file)
+    coverImageUrl.value = data.url
+  } catch {
+    alert('封面圖上傳失敗')
+  } finally {
+    coverImageUploading.value = false
+    if (target) target.value = ''
+  }
+}
+
+function removeCoverImage() {
+  coverImageUrl.value = null
+}
 
 const editor = useEditor({
   extensions: [
@@ -394,19 +445,20 @@ function confirmImage() {
 
 async function submitArticle() {
   try {
-    const { data, status } = await createPost({
+    const { status } = await createPost({
       title: title.value,
       slug: slug.value,
       metaDescription: metaDescription.value,
       content: editor.value?.getHTML() || '',
+      og_image: coverImageUrl.value,
     })
 
     if (status) {
       navigateTo('/admin/posts')
     }
-  } catch (err: any) {
+  } catch (err) {
     console.error(err)
-    alert('發佈失敗: ' + err.response?.data?.message || err.message)
+    alert('發佈失敗: ' + (err instanceof Error ? err.message : '未知錯誤'))
   }
 }
 

--- a/pages/admin/posts/edit/[id].vue
+++ b/pages/admin/posts/edit/[id].vue
@@ -27,6 +27,42 @@
       class="mb-4 w-full rounded border border-gray-300 p-2"
     />
 
+    <!-- 封面圖 -->
+    <div class="mb-4">
+      <p class="mb-1 text-sm font-medium text-gray-700">封面圖</p>
+      <div
+        v-if="coverImageUrl"
+        class="relative w-full overflow-hidden rounded border border-gray-200"
+      >
+        <img
+          :src="coverImageUrl"
+          alt="封面圖預覽"
+          class="h-48 w-full object-cover"
+        />
+        <button
+          type="button"
+          class="absolute top-2 right-2 rounded bg-black/50 px-2 py-1 text-xs text-white hover:bg-black/70"
+          @click="removeCoverImage"
+        >
+          移除
+        </button>
+      </div>
+      <label
+        v-else
+        class="flex h-32 w-full cursor-pointer flex-col items-center justify-center rounded border-2 border-dashed border-gray-300 text-sm text-gray-400 hover:border-gray-400"
+      >
+        <span v-if="coverImageUploading">上傳中...</span>
+        <span v-else>點擊上傳封面圖</span>
+        <input
+          ref="coverImageInput"
+          type="file"
+          accept="image/*"
+          class="hidden"
+          @change="handleCoverImageUpload"
+        />
+      </label>
+    </div>
+
     <!-- 做成元件 -->
     <UModal v-model:open="showModal" title="設定圖片資訊">
       <template #body>
@@ -59,25 +95,25 @@
       <div class="control-group">
         <div class="button-group mb-4">
           <button
-            @click="editor.chain().focus().toggleBold().run()"
             :disabled="!editor.can().chain().focus().toggleBold().run()"
             :class="{ 'is-active': editor.isActive('bold') }"
+            @click="editor.chain().focus().toggleBold().run()"
           >
             Bold
           </button>
 
           <button
-            @click="editor.chain().focus().toggleItalic().run()"
             :disabled="!editor.can().chain().focus().toggleItalic().run()"
             :class="{ 'is-active': editor.isActive('italic') }"
+            @click="editor.chain().focus().toggleItalic().run()"
           >
             Italic
           </button>
 
           <button
-            @click="editor.chain().focus().toggleStrike().run()"
             :disabled="!editor.can().chain().focus().toggleStrike().run()"
             :class="{ 'is-active': editor.isActive('strike') }"
+            @click="editor.chain().focus().toggleStrike().run()"
           >
             Strike
           </button>
@@ -85,115 +121,115 @@
           <!-- upload image  -->
           <button @click="triggerFileInput">Upload Image</button>
           <input
-            type="file"
-            @change="handleUploadImage"
-            class="hidden"
             ref="fileInput"
+            type="file"
+            class="hidden"
+            @change="handleUploadImage"
           />
           <button @click="addImage">Set Image URL</button>
 
           <button
-            @click="editor.chain().focus().toggleCode().run()"
             :disabled="!editor.can().chain().focus().toggleCode().run()"
             :class="{ 'is-active': editor.isActive('code') }"
+            @click="editor.chain().focus().toggleCode().run()"
           >
             <Icon name="i-ic:baseline-code" />
           </button>
 
           <button
-            @click="editor.chain().focus().toggleCodeBlock().run()"
             :class="{ 'is-active': editor.isActive('codeBlock') }"
+            @click="editor.chain().focus().toggleCodeBlock().run()"
           >
             Code block
           </button>
 
           <button
-            @click="editor.chain().focus().setParagraph().run()"
             :class="{ 'is-active': editor.isActive('paragraph') }"
+            @click="editor.chain().focus().setParagraph().run()"
           >
             Paragraph
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 1 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
           >
             H1
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 2 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
           >
             H2
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 3 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
           >
             H3
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 4 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 4 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 4 }).run()"
           >
             H4
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 5 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 5 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 5 }).run()"
           >
             H5
           </button>
 
           <button
-            @click="editor.chain().focus().toggleHeading({ level: 6 }).run()"
             :class="{ 'is-active': editor.isActive('heading', { level: 6 }) }"
+            @click="editor.chain().focus().toggleHeading({ level: 6 }).run()"
           >
             H6
           </button>
 
           <button
-            @click="editor.chain().focus().toggleBulletList().run()"
             :class="{ 'is-active': editor.isActive('bulletList') }"
+            @click="editor.chain().focus().toggleBulletList().run()"
           >
             Bullet list
           </button>
 
           <button
-            @click="editor.chain().focus().toggleOrderedList().run()"
             :class="{ 'is-active': editor.isActive('orderedList') }"
+            @click="editor.chain().focus().toggleOrderedList().run()"
           >
             Ordered list
           </button>
 
           <button
-            @click="setLink"
             :class="{ 'is-active': editor.isActive('link') }"
+            @click="setLink"
           >
             Set link
           </button>
 
           <button
-            @click="editor.chain().focus().unsetLink().run()"
             :disabled="!editor.isActive('link')"
+            @click="editor.chain().focus().unsetLink().run()"
           >
             Unset link
           </button>
 
           <button
-            @click="editor.chain().focus().undo().run()"
             :disabled="!editor.can().chain().focus().undo().run()"
+            @click="editor.chain().focus().undo().run()"
           >
             <Icon name="i-flowbite:undo-outline" />
           </button>
 
           <button
-            @click="editor.chain().focus().redo().run()"
             :disabled="!editor.can().chain().focus().redo().run()"
+            @click="editor.chain().focus().redo().run()"
           >
             <Icon name="i-flowbite:undo-solid" />
           </button>
@@ -257,10 +293,7 @@ definePageMeta({
 const route = useRoute()
 const id = Number(route.params.id)
 
-const { data, pending, error, refresh } = useAsyncData<ApiResponse<Post>>(
-  'post',
-  () => getPost(id),
-)
+const { data } = useAsyncData<ApiResponse<Post>>('post', () => getPost(id))
 
 const lowlight = createLowlight(all)
 
@@ -270,6 +303,29 @@ lowlight.register('js', js)
 const title = ref('')
 const slug = ref('')
 const metaDescription = ref('')
+const coverImageUrl = ref<string | null>(null)
+const coverImageUploading = ref(false)
+const coverImageInput = ref<HTMLInputElement | null>(null)
+
+async function handleCoverImageUpload(event: Event) {
+  const target = event.target as HTMLInputElement | null
+  const file = target?.files?.[0]
+  if (!file) return
+  coverImageUploading.value = true
+  try {
+    const { data } = await uploadImage(file)
+    coverImageUrl.value = data.url
+  } catch {
+    alert('封面圖上傳失敗')
+  } finally {
+    coverImageUploading.value = false
+    if (target) target.value = ''
+  }
+}
+
+function removeCoverImage() {
+  coverImageUrl.value = null
+}
 
 const editor = useEditor({
   extensions: [
@@ -367,19 +423,20 @@ function confirmImage() {
 
 async function submitArticle() {
   try {
-    const { data, status } = await updatePost(id, {
+    const { status } = await updatePost(id, {
       title: title.value,
       slug: slug.value,
       meta_description: metaDescription.value,
       content: editor.value?.getHTML() || '',
+      og_image: coverImageUrl.value,
     })
 
     if (status) {
       navigateTo('/admin/posts')
     }
-  } catch (err: any) {
+  } catch (err) {
     console.error(err)
-    alert('發佈失敗: ' + err.response?.data?.message || err.message)
+    alert('發佈失敗: ' + (err instanceof Error ? err.message : '未知錯誤'))
   }
 }
 
@@ -391,6 +448,7 @@ watchEffect(async () => {
     title.value = data.value.data.title
     slug.value = data.value.data.slug || ''
     metaDescription.value = data.value.data.meta_description || ''
+    coverImageUrl.value = data.value.data.og_image || null
   }
 })
 

--- a/pages/blog/[id]/[slug].vue
+++ b/pages/blog/[id]/[slug].vue
@@ -14,6 +14,13 @@
           </div>
         </div>
       </div>
+      <div v-if="post?.og_image" class="my-6">
+        <img
+          :src="post.og_image"
+          :alt="title"
+          class="w-full rounded-lg object-cover"
+        />
+      </div>
       <div v-html="data?.data.content" class="tiptap"></div>
     </div>
   </div>
@@ -27,7 +34,7 @@ const route = useRoute()
 const id = Number(route.params.id)
 const slugParam = route.params.slug
 
-const { data } = await useAsyncData<ApiResponse<Post>>('post', () =>
+const { data } = await useAsyncData<ApiResponse<Post>>(`post-${id}`, () =>
   getPost(id),
 )
 

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -1,27 +1,40 @@
 <template>
-  <div class="container mx-auto lg:max-w-5xl">
-    <div class="grid gap-2 lg:grid-cols-3">
+  <div class="container mx-auto px-4 py-12 lg:max-w-5xl">
+    <div class="grid gap-12 lg:grid-cols-3">
       <div class="col-span-2">
-        <div v-if="posts">
+        <div v-if="postsData.length > 0">
           <BlogPost v-for="item in postsData" :key="item.id" :item="item" />
-          <div class="my-10 flex justify-center">
+          <div class="mt-10 flex justify-center">
             <UPagination
               v-model:page="page"
               active-color="neutral"
               active-variant="subtle"
               :items-per-page="perPage"
-              :total="postsData.length"
+              :total="posts?.total ?? 0"
             />
           </div>
         </div>
-        <div v-else class="mt-10 bg-white px-4 text-center lg:p-4">
-          尚未新增文章
+        <div v-else class="py-20 text-center text-gray-400">尚未新增文章</div>
+      </div>
+
+      <aside class="hidden lg:block">
+        <div class="sticky top-12">
+          <h3
+            class="mb-4 text-xs font-semibold tracking-widest text-gray-400 uppercase"
+          >
+            熱門標籤
+          </h3>
+          <div class="flex flex-wrap gap-2">
+            <span
+              v-for="tag in popularTags"
+              :key="tag"
+              class="cursor-pointer rounded-full border border-gray-200 px-3 py-1 text-sm text-gray-500 transition-colors hover:border-gray-400 hover:text-gray-700"
+            >
+              {{ tag }}
+            </span>
+          </div>
         </div>
-      </div>
-      <div class="mt-10 hidden px-7 lg:block">
-        <Icon name="fa-solid:tag" class="h-4 w-4 text-[#5DADE2]" />
-        <span class="pl-2">熱門標籤</span>
-      </div>
+      </aside>
     </div>
   </div>
 </template>
@@ -32,9 +45,7 @@ import { getPosts } from '~/api/posts/index'
 
 useHead({
   title: 'Fire Life - 網站架設與前端技術與接案分享',
-  htmlAttrs: {
-    lang: 'zh-TW',
-  },
+  htmlAttrs: { lang: 'zh-TW' },
   meta: [
     {
       name: 'description',
@@ -56,27 +67,15 @@ useHead({
   link: [{ rel: 'canonical', href: 'https://firelifedev.com/blog' }],
 })
 
+const popularTags = ['前端開發', 'Nuxt', 'Vue', '接案', '網站架設']
+
 const perPage = ref(10)
-let page = ref(1)
-const {
-  data: posts,
-  pending,
-  error,
-  refresh,
-} = await useAsyncData<PostsResponse>(`posts-1`, () =>
-  getPosts({
-    page: page.value,
-    perPage: perPage.value,
-  }),
+const page = ref(1)
+
+const { data: posts } = await useAsyncData<PostsResponse>(
+  () => `posts-page-${page.value}`,
+  () => getPosts({ page: page.value, perPage: perPage.value }),
 )
 
-const postsData = computed(() => {
-  if (!posts.value?.data.length) return []
-
-  return posts.value.data
-})
-
-watch([page], () => {
-  refresh()
-})
+const postsData = computed(() => posts.value?.data ?? [])
 </script>


### PR DESCRIPTION
## Summary

- **封面圖功能**：Admin 建立/編輯文章頁面新增封面圖上傳（含預覽與移除），文章詳情頁顯示封面圖
- **文章卡片 UI 重設計**：`BlogPost` 元件加入縮圖、閱讀時間估算、置頂標籤、格式化日期顯示
- **Bug fix**：`useAsyncData` key 改為動態（`posts-page-${page}`、`post-${id}`），修正分頁快取錯誤並移除多餘的 `watch` + `refresh()` pattern
- **Type 修正**：`og_image` 改為 `string | null`，`CreatePostPayload` 補上 `og_image` 欄位
- **程式碼品質**：錯誤處理從 `err: any` 改為 `err instanceof Error`，Vue 屬性排序符合規範

## Test plan

- [ ] Admin 建立文章：上傳封面圖 → 預覽正確 → 儲存後文章詳情頁顯示封面圖
- [ ] Admin 編輯文章：現有封面圖正確載入 → 可移除並重新上傳
- [ ] Blog 列表：換頁後資料正確更新（動態 key 生效）
- [ ] Blog 詳情：不同文章間導航，資料不會互相污染（動態 key 生效）
- [ ] 文章卡片顯示縮圖、閱讀時間、置頂標籤

🤖 Generated with [Claude Code](https://claude.com/claude-code)