### PR TITLE
style: unify page h2 heading to text-3xl, remove bg-cream-peach

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,7 @@
   <div class="flex min-h-screen flex-col">
     <LayoutHeader />
     <LayoutBanner v-if="route.path === '/'" />
-    <main class="bg-cream-peach flex-1 pt-14">
+    <main class="flex-1 pt-14">
       <slot />
     </main>
     <LayoutFooter />

--- a/pages/cart/index.vue
+++ b/pages/cart/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mx-auto mt-7 lg:max-w-5xl">
-    <h2 class="my-10 text-center font-bold tracking-widest">購物車</h2>
+    <h2 class="my-10 text-center text-3xl font-bold tracking-widest">購物車</h2>
     <ClientOnly>
       <div v-if="cartItems.length === 0" class="text-center text-gray-500">
         購物車目前是空的。

--- a/pages/contact/index.vue
+++ b/pages/contact/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mx-auto px-6 lg:max-w-5xl">
-    <h2 class="my-10 text-center font-bold tracking-widest">聯絡資訊</h2>
+    <h2 class="my-10 text-center text-3xl font-bold tracking-widest">聯絡資訊</h2>
 
     <div class="space-y-6 rounded-2xl">
       <p class="text-center text-gray-600">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="bg-cream-peach -mt-16 px-4">
+  <div class="-mt-16 px-4">
     <section class="pt-10 text-center">
-      <h2 class="tracking-widest">服務項目</h2>
+      <h2 class="text-3xl font-bold tracking-widest">服務項目</h2>
       <sections-services-section />
     </section>
     <section class="container mx-auto mt-40 text-center lg:max-w-5xl">

--- a/pages/process/index.vue
+++ b/pages/process/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container mx-auto px-6 lg:max-w-5xl">
     <h2
-      class="my-10 text-center text-3xl font-bold tracking-wide text-gray-900"
+      class="my-10 text-center text-3xl font-bold tracking-widest"
     >
       合作流程
     </h2>

--- a/pages/service/index.vue
+++ b/pages/service/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mx-auto lg:max-w-5xl">
-    <h2 class="my-10 text-center text-2xl font-bold tracking-widest">
+    <h2 class="my-10 text-center text-3xl font-bold tracking-widest">
       服務項目
     </h2>
     <sections-services-section />

--- a/pages/works/index.vue
+++ b/pages/works/index.vue
@@ -1,46 +1,40 @@
 <template>
-  <div>
-    <section class="py-16">
-      <div class="mx-auto max-w-7xl px-4">
-        <h2
-          class="mb-12 text-center text-2xl font-bold tracking-widest md:text-3xl"
-        >
-          網站範例
-        </h2>
+  <div class="mx-auto max-w-7xl px-4">
+    <h2 class="my-10 text-center text-3xl font-bold tracking-widest">
+      網站範例
+    </h2>
 
-        <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <div
-            v-for="(demo, index) in demos"
-            :key="index"
-            class="group relative flex flex-col overflow-hidden bg-white shadow-md"
-          >
-            <div class="h-48 w-full overflow-hidden">
-              <img
-                :src="demo.img"
-                :alt="demo.title"
-                class="h-full w-full object-cover"
-              />
-            </div>
+    <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <div
+        v-for="(demo, index) in demos"
+        :key="index"
+        class="group relative flex flex-col overflow-hidden bg-white shadow-md"
+      >
+        <div class="h-48 w-full overflow-hidden">
+          <img
+            :src="demo.img"
+            :alt="demo.title"
+            class="h-full w-full object-cover"
+          />
+        </div>
 
-            <div class="flex flex-1 flex-col p-6">
-              <h3 class="mb-2 text-lg font-semibold text-gray-800">
-                {{ demo.title }}
-              </h3>
-              <p class="flex-1 text-sm text-gray-600">{{ demo.desc }}</p>
+        <div class="flex flex-1 flex-col p-6">
+          <h3 class="mb-2 text-lg font-semibold text-gray-800">
+            {{ demo.title }}
+          </h3>
+          <p class="flex-1 text-sm text-gray-600">{{ demo.desc }}</p>
 
-              <div class="mt-4 flex justify-end">
-                <NuxtLink
-                  :to="demo.link"
-                  class="text-sm font-semibold text-sky-500 group-hover:underline"
-                >
-                  查看範例 →
-                </NuxtLink>
-              </div>
-            </div>
+          <div class="mt-4 flex justify-end">
+            <NuxtLink
+              :to="demo.link"
+              class="text-sm font-semibold text-sky-500 group-hover:underline"
+            >
+              查看範例 →
+            </NuxtLink>
           </div>
         </div>
       </div>
-    </section>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- 統一所有公開頁面主標題 h2 為 `text-3xl font-bold tracking-widest`
- 修正 `service`、`contact`、`cart` 缺少字體大小、`process` 使用 `tracking-wide` 不一致的問題
- 移除 `bg-cream-peach`（`layouts/default.vue`、`pages/index.vue`）

## Test plan
- [ ] 瀏覽各頁面（首頁、服務、流程、作品、聯絡、購物車）確認標題大小一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)