### PR TITLE
fix: remove commented-out dead code in getAdminOrderById

### DIFF
--- a/api/order/index.ts
+++ b/api/order/index.ts
@@ -46,24 +46,6 @@ export const checkoutOrder = async (orderNo: string): Promise<string> => {
   }
 }
 
-// export const getAdminOrderById = async (
-//   id: string | number,
-// ): Promise<AdminOrderDetail> => {
-//   const { $api } = useNuxtApp()
-//   try {
-//     const res = await $api.get(`/admin/orders/${id}`)
-//     const result = adminOrderDetailResponseSchema.safeParse(res.data)
-//     if (!result.success) {
-//       console.error('Zod validation failed:', result.error.issues)
-//       throw new Error('API 回傳資料格式不正確')
-//     }
-//     return result.data.data
-//   } catch (error) {
-//     console.error('API request failed:', error)
-//     throw error
-//   }
-// }
-
 export const getAdminOrderById = async (
   id: string | number,
 ): Promise<AdminOrderDetail> => {


### PR DESCRIPTION
## Summary
- 刪除 `api/order/index.ts` 中被 comment 掉的舊版 `getAdminOrderById` 實作（原 lines 49–65）
- 該區塊與下方現行實作邏輯重複，屬於純 dead code

## Test plan
- [ ] 確認 `/admin/orders/:id` 詳情頁仍正常載入
- [ ] 確認 TypeScript build 無錯誤：`npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)